### PR TITLE
put tfplan file to s3

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,10 +26,7 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Download plan file
-        uses: actions/download-artifact@v4
-        with:
-          name: terraform-plan
-          path: ./
+        run: aws s3 cp s3://tfstate-basic-app/terraform-plan/tfplan tfplan
       - name: Terraform init
         run: terraform init
       - name: Terraform apply

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -30,8 +30,5 @@ jobs:
       - name: Terraform plan
         run: terraform plan -out=tfplan
       - name: Upload plan file
-        uses: actions/upload-artifact@v4
-        with:
-          name: terraform-plan
-          path: tfplan
+        run: aws s3 cp tfplan s3://tfstate-basic-app/terraform-plan/tfplan
 


### PR DESCRIPTION
put tfplan file to s3
because artifact can not be passed between different workflows