### PR TITLE
cicd: fix ecr dkr endpoint error

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "sg_ingress_rule_for_web" {
 resource "aws_subnet" "private_subnet_for_app" {
   vpc_id            = aws_vpc.vpc.id
   cidr_block        = "10.0.32.0/24"
-  availability_zone = "ap-northeast-1a"
+  availability_zone = "ap-northeast-1c"
   tags = {
     Name = "basicApp-private-subnet-for-app"
   }


### PR DESCRIPTION
Fix error below.

│ Error: creating EC2 VPC Endpoint (com.amazonaws.ap-northeast-1.ecr.dkr): DuplicateSubnetsInSameZone: Found another VPC endpoint subnet in the availability zone of subnet-0be4aa532f40a2110. VPC endpoint subnets should be in different availability zones supported by the VPC endpoint service.
│ 	status code: 400, request id: ea2d8ef7-0ced-4ad5-93b8-7991cdf4eb6f
│ 
│   with aws_vpc_endpoint.ecr_dkr_endpoint,
│   on network.tf line 260, in resource "aws_vpc_endpoint" "ecr_dkr_endpoint":
│  260: resource "aws_vpc_endpoint" "ecr_dkr_endpoint" {