### PR TITLE
cicd: fix vpc endpoint error.

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -3,7 +3,9 @@
 ######################
 
 resource "aws_vpc" "vpc" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
   tags = {
     Name = "basicApp-vpc"
   }


### PR DESCRIPTION
Fix error below.

│ Error: creating EC2 VPC Endpoint (com.amazonaws.ap-northeast-1.ecr.api): InvalidParameter: Enabling private DNS requires both enableDnsSupport and enableDnsHostnames VPC attributes set to true for vpc-01206ea4bcaf0bba9
│ 	status code: 400, request id: 1be1ab16-4085-4a30-acc6-9db461816735
│ 
│   with aws_vpc_endpoint.ecr_api_endpoint,
│   on network.tf line 242, in resource "aws_vpc_endpoint" "ecr_api_endpoint":
│  242: resource "aws_vpc_endpoint" "ecr_api_endpoint" {
│ 
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.